### PR TITLE
FIX: Correctly toggle checkboxes when used with text modifiers or codeblocks

### DIFF
--- a/assets/javascripts/discourse/initializers/checklist.js.es6
+++ b/assets/javascripts/discourse/initializers/checklist.js.es6
@@ -52,11 +52,22 @@ export function checklistSyntax($elem, post) {
 
           // make the first run go to index = 0
           let nth = -1;
+          let found = false;
           const newRaw = result.raw.replace(
             /\[(\s|\_|\-|\x|\\?\*)?\]/gi,
             (match, ignored, off) => {
+              if (found) {
+                return match;
+              }
+
               nth += blocks.every(b => b[0] > off + match.length || off > b[1]);
-              return nth === idx ? newValue : match;
+
+              if (nth === idx) {
+                found = true; // Do not replace any further matches
+                return newValue;
+              }
+
+              return match;
             }
           );
 

--- a/assets/javascripts/discourse/initializers/checklist.js.es6
+++ b/assets/javascripts/discourse/initializers/checklist.js.es6
@@ -39,7 +39,10 @@ export function checklistSyntax($elem, post) {
           [
             /`[^`\n]*\n?[^`\n]*`/gm,
             /^```[^]*?^```/gm,
-            /\[code\][^]*?\[\/code\]/gm
+            /\[code\][^]*?\[\/code\]/gm,
+            /_.*?_/gm,
+            /\*.*?\*/gm,
+            /~~.*?~~/gm,
           ].forEach(regex => {
             let match;
             while ((match = regex.exec(result.raw)) != null) {

--- a/spec/pretty_text_spec.rb
+++ b/spec/pretty_text_spec.rb
@@ -8,12 +8,12 @@ describe PrettyText do
     it 'can properly bake boxes' do
       md = <<~MD
         [],[ ],[_];[-]X[x]X [*] [\\*] are all checkboxes
-        `[ ]` [x](hello) *[ ]* **[ ]** are not checkboxes
+        `[ ]` [x](hello) *[ ]* **[ ]** _[ ]_ __[ ]__ ~~[ ]~~ are not checkboxes
       MD
 
       html = <<~HTML
         <p><span class="chcklst-box fa fa-square-o fa-fw"></span>,<span class="chcklst-box fa fa-square-o fa-fw"></span>,<span class="chcklst-box fa fa-square fa-fw"></span>;<span class="chcklst-box fa fa-minus-square-o fa-fw"></span>X<span class="chcklst-box checked fa fa-check-square fa-fw"></span>X <span class="chcklst-box checked fa fa-check-square-o fa-fw"></span> <span class="chcklst-box checked fa fa-check-square-o fa-fw"></span> are all checkboxes<br>
-        <code>[ ]</code> <a>x</a> <em>[ ]</em> <strong>[ ]</strong> are not checkboxes</p>
+        <code>[ ]</code> <a>x</a> <em>[ ]</em> <strong>[ ]</strong> <em>[ ]</em> <strong>[ ]</strong> <s>[ ]</s> are not checkboxes</p>
       HTML
       cooked = PrettyText.cook(md)
       expect(cooked).to eq(html.strip)

--- a/test/javascripts/lib/checklist-test.js.es6
+++ b/test/javascripts/lib/checklist-test.js.es6
@@ -3,12 +3,16 @@ import { checklistSyntax } from "discourse/plugins/discourse-checklist/discourse
 
 QUnit.module("initializer:checklist");
 
+
+
 QUnit.test("correct checkbox is selected", assert => {
-  const raw = `Hi there,
-
-It seems that a code block followed by a checklist breaks things.
-
+  const raw = `
 \`[x]\`
+*[x]*
+**[x]**
+_[x]_
+__[x]__
+~~[x]~~
 
 [code]
 [\*]
@@ -23,18 +27,21 @@ It seems that a code block followed by a checklist breaks things.
 [ ]
 [\*]
 \`\`\`
-Will create a list like this:
+
+Actual checkboxes:
 [] first
 [*] second
 [x] third
 [_] fourth
-
-Clicking the boxes will ruin the code block and the list becomes unresponsive.`;
+`;
 
   const cooked = `<div class="cooked">
-<p>Hi there,</p>
-<p>It seems that a code block followed by a checklist breaks things.</p>
 <pre>[*]</pre>
+<em>[*]</em>
+<strong>[*]</strong>
+<em>[*]</em>
+<strong>[*]</strong>
+<s>[*]</s>
 <pre><code>[\*]
 [ ]
 [ ]
@@ -45,18 +52,16 @@ Clicking the boxes will ruin the code block and the list becomes unresponsive.`;
 [ ]
 [\*]
 </code></pre>
-<p>Will create a list like this:<br>
-<span class="chcklst-box fa fa-square-o fa-fw" style="cursor: pointer;"></span><br>
-<span class="chcklst-box checked fa fa-check-square-o fa-fw" style="cursor: pointer;"></span><br>
-<span class="chcklst-box checked fa fa-check-square fa-fw" style="cursor: pointer;"></span><br>
-<span class="chcklst-box fa fa-square fa-fw" style="cursor: pointer;"></span></p>
-<p>Clicking the boxes will ruin the code block and the list becomes unresponsive.</p>
+<p>Actual checkboxes:<br>
+<span class="chcklst-box fa fa-square-o fa-fw" style="cursor: pointer;"></span> first<br>
+<span class="chcklst-box checked fa fa-check-square-o fa-fw" style="cursor: pointer;"></span> second<br>
+<span class="chcklst-box checked fa fa-check-square fa-fw" style="cursor: pointer;"></span> third<br>
+<span class="chcklst-box fa fa-square fa-fw" style="cursor: pointer;"></span> fourth</p>
 </div>`;
 
   const model = Post.create({ id: 42, can_edit: true });
-
-  const $elem = $(cooked);
   const decoratorHelper = { getModel: () => model };
+  const $elem = $(cooked);
 
   // eslint-disable-next-line no-undef
   server.get("/posts/42", () => [
@@ -69,7 +74,8 @@ Clicking the boxes will ruin the code block and the list becomes unresponsive.`;
 
   const done = assert.async();
   model.save = fields => {
-    assert.ok(fields.raw.indexOf("[ ] third") !== -1);
+    assert.ok(fields.raw.includes("[ ] third"));
+
     done();
   };
 


### PR DESCRIPTION
Fixes two issues with:

1. Checkboxes preceding codeblocks – toggling a checkbox, would also toggle all instances of `[]` in a following code block

2. Checkboxes following various text modifiers – every instance of e.g. `~~[]~~` or `**[]**` would cause a mismatch between what's being clicked and what gets actually toggled (a similar issue to #16)