### PR TITLE
FIX: temporary solution when option contains **

### DIFF
--- a/assets/javascripts/discourse/initializers/checklist.js.es6
+++ b/assets/javascripts/discourse/initializers/checklist.js.es6
@@ -41,7 +41,6 @@ export function checklistSyntax($elem, post) {
             /^```[^]*?^```/gm,
             /\[code\][^]*?\[\/code\]/gm,
             /_.*?_/gm,
-            /\*.*?\*/gm,
             /~~.*?~~/gm
           ].forEach(regex => {
             let match;


### PR DESCRIPTION
I noticed that when option contains **strong** word, you cannot click that option.
I found regex which is causing that but I guess that removing it is not an ideal solution

![Screenshot from 2019-10-04 14-09-36](https://user-images.githubusercontent.com/72780/66180666-3a1ba180-e6b1-11e9-8d40-87c2c692405c.png)

@CvX could you take a look?