### PR TITLE
FIX: make other checkboxes read-only while updating the one.

### DIFF
--- a/assets/javascripts/discourse/initializers/checklist.js
+++ b/assets/javascripts/discourse/initializers/checklist.js
@@ -19,6 +19,7 @@ export function checklistSyntax($elem, postDecorator) {
   const $boxes = $elem.find(".chcklst-box");
   const postWidget = postDecorator.widget;
   const postModel = postDecorator.getModel();
+  const removeReadonlyClass = () => $boxes.removeClass("readonly");
 
   if (!postModel.can_edit) {
     return;
@@ -32,14 +33,14 @@ export function checklistSyntax($elem, postDecorator) {
         return;
       }
 
-      $boxes.addClass('readonly');
+      $boxes.addClass("readonly");
 
       const newValue = $box.hasClass("checked") ? "[ ]" : "[x]";
 
       $box.after(iconHTML("spinner", { class: "fa-spin" })).hide();
 
-      ajax(`/posts/${postModel.id}`, { type: "GET", cache: false }).then(
-        (result) => {
+      ajax(`/posts/${postModel.id}`, { type: "GET", cache: false })
+        .then((result) => {
           const blocks = [];
 
           // Computing offsets where checkbox are not evaluated (i.e. inside
@@ -102,13 +103,17 @@ export function checklistSyntax($elem, postDecorator) {
           });
 
           if (save && save.then) {
-            save.then(() => {
-              postWidget.attrs.isSaving = false;
-              postWidget.scheduleRerender();
-            }).finally(() => $boxes.removeClass('readonly'));
+            save
+              .then(() => {
+                postWidget.attrs.isSaving = false;
+                postWidget.scheduleRerender();
+              })
+              .finally(removeReadonlyClass);
+          } else {
+            removeReadonlyClass();
           }
-        }
-      ).fail(() => $boxes.removeClass('readonly'));
+        })
+        .catch(removeReadonlyClass);
     });
   });
 

--- a/assets/javascripts/discourse/initializers/checklist.js
+++ b/assets/javascripts/discourse/initializers/checklist.js
@@ -38,10 +38,10 @@ export function checklistSyntax(elem, postDecorator) {
       }
 
       const newValue = classList.contains("checked") ? "[ ]" : "[x]";
-      const template = document.createElement('template');
+      const template = document.createElement("template");
 
       template.innerHTML = iconHTML("spinner", { class: "fa-spin" });
-      box.insertAdjacentElement('afterend', template.content.firstChild);
+      box.insertAdjacentElement("afterend", template.content.firstChild);
       box.classList.add("hidden");
       boxes.forEach((e) => e.classList.add("readonly"));
 

--- a/assets/javascripts/discourse/initializers/checklist.js
+++ b/assets/javascripts/discourse/initializers/checklist.js
@@ -11,6 +11,18 @@ function initializePlugin(api) {
   }
 }
 
+function removeReadonlyClass() {
+  Array.from(document.getElementsByClassName("chcklst-box readonly")).forEach((e) =>
+    e.classList.remove("readonly")
+  );
+}
+
+function addReadonlyClass() {
+  Array.from(document.getElementsByClassName("chcklst-box")).forEach((e) =>
+    e.classList.add("readonly")
+  );
+}
+
 export function checklistSyntax($elem, postDecorator) {
   if (!postDecorator) {
     return;
@@ -19,7 +31,6 @@ export function checklistSyntax($elem, postDecorator) {
   const $boxes = $elem.find(".chcklst-box");
   const postWidget = postDecorator.widget;
   const postModel = postDecorator.getModel();
-  const removeReadonlyClass = () => $boxes.removeClass("readonly");
 
   if (!postModel.can_edit) {
     return;
@@ -28,12 +39,13 @@ export function checklistSyntax($elem, postDecorator) {
   $boxes.each((idx, val) => {
     $(val).click((ev) => {
       const $box = $(ev.currentTarget);
+      const classList = ev.currentTarget;
 
-      if ($box.hasClass("permanent") || $box.hasClass("readonly")) {
+      if (classList.contains("permanent") || classList.contains("readonly")) {
         return;
       }
 
-      $boxes.addClass("readonly");
+      addReadonlyClass();
 
       const newValue = $box.hasClass("checked") ? "[ ]" : "[x]";
 
@@ -105,7 +117,7 @@ export function checklistSyntax($elem, postDecorator) {
           if (save && save.then) {
             save
               .then(() => {
-                postWidget.attrs.isSaving = false;
+                postWidget.attrs.set("isSaving", false);
                 postWidget.scheduleRerender();
               })
               .finally(removeReadonlyClass);

--- a/assets/javascripts/discourse/initializers/checklist.js
+++ b/assets/javascripts/discourse/initializers/checklist.js
@@ -39,7 +39,7 @@ export function checklistSyntax($elem, postDecorator) {
   $boxes.each((idx, val) => {
     $(val).click((ev) => {
       const $box = $(ev.currentTarget);
-      const classList = ev.currentTarget;
+      const classList = ev.currentTarget.classList;
 
       if (classList.contains("permanent") || classList.contains("readonly")) {
         return;

--- a/assets/javascripts/discourse/initializers/checklist.js
+++ b/assets/javascripts/discourse/initializers/checklist.js
@@ -28,9 +28,11 @@ export function checklistSyntax($elem, postDecorator) {
     $(val).click((ev) => {
       const $box = $(ev.currentTarget);
 
-      if ($box.hasClass("permanent")) {
+      if ($box.hasClass("permanent") || $box.hasClass("readonly")) {
         return;
       }
+
+      $boxes.addClass('readonly');
 
       const newValue = $box.hasClass("checked") ? "[ ]" : "[x]";
 
@@ -103,10 +105,10 @@ export function checklistSyntax($elem, postDecorator) {
             save.then(() => {
               postWidget.attrs.isSaving = false;
               postWidget.scheduleRerender();
-            });
+            }).finally(() => $boxes.removeClass('readonly'));
           }
         }
-      );
+      ).fail(() => $boxes.removeClass('readonly'));
     });
   });
 

--- a/assets/javascripts/discourse/initializers/checklist.js
+++ b/assets/javascripts/discourse/initializers/checklist.js
@@ -12,9 +12,9 @@ function initializePlugin(api) {
 }
 
 function removeReadonlyClass() {
-  Array.from(document.getElementsByClassName("chcklst-box readonly")).forEach(
-    (e) => e.classList.remove("readonly")
-  );
+  Array.from(
+    document.getElementsByClassName("chcklst-box readonly")
+  ).forEach((e) => e.classList.remove("readonly"));
 }
 
 function addReadonlyClass() {

--- a/assets/javascripts/discourse/initializers/checklist.js
+++ b/assets/javascripts/discourse/initializers/checklist.js
@@ -12,8 +12,8 @@ function initializePlugin(api) {
 }
 
 function removeReadonlyClass() {
-  Array.from(document.getElementsByClassName("chcklst-box readonly")).forEach((e) =>
-    e.classList.remove("readonly")
+  Array.from(document.getElementsByClassName("chcklst-box readonly")).forEach(
+    (e) => e.classList.remove("readonly")
   );
 }
 

--- a/assets/stylesheets/checklist.scss
+++ b/assets/stylesheets/checklist.scss
@@ -51,6 +51,10 @@ span.chcklst-box {
       );
     }
   }
+
+  &.readonly {
+    pointer-events: none;
+  }
 }
 
 .fa-spin {

--- a/assets/stylesheets/checklist.scss
+++ b/assets/stylesheets/checklist.scss
@@ -22,6 +22,8 @@ span.chcklst-stroked {
 }
 
 span.chcklst-box {
+  cursor: pointer;
+
   &:before {
     display: inline-block;
     vertical-align: middle;
@@ -54,6 +56,10 @@ span.chcklst-box {
 
   &.readonly {
     pointer-events: none;
+  }
+
+  &.hidden {
+    display: none;
   }
 }
 

--- a/test/javascripts/lib/checklist-test.js
+++ b/test/javascripts/lib/checklist-test.js
@@ -35,6 +35,24 @@ acceptance("discourse-checklist | checklist", function (needs) {
     ]);
   });
 
+  test("works if clicked in a very small interval", async function (assert) {
+    const [$elem, updated] = await prepare(`
+[ ] first
+[x] second
+[ ] third
+[ ] fourth
+[x] fifth
+[x] sixth
+    `);
+
+    $elem.find(".chcklst-box").each(() => $(this).click());
+
+    const output = await updated;
+    assert.ok(output.includes("[x] first"));
+    assert.ok(output.includes("[ ] second"));
+    assert.ok(output.includes("[x] third"));
+  });
+
   test("checkbox before a code block", async function (assert) {
     const [$elem, updated] = await prepare(`
 [ ] first

--- a/test/javascripts/lib/checklist-test.js
+++ b/test/javascripts/lib/checklist-test.js
@@ -15,7 +15,7 @@ async function prepare(raw) {
   const decoratorHelper = { getModel: () => model };
 
   const $elem = $(cooked.string);
-  checklistSyntax($elem, decoratorHelper);
+  checklistSyntax($elem[0], decoratorHelper);
 
   currentRaw = raw;
 

--- a/test/javascripts/lib/checklist-test.js
+++ b/test/javascripts/lib/checklist-test.js
@@ -14,7 +14,7 @@ async function prepare(raw) {
   const model = Post.create({ id: 42, can_edit: true });
   const decoratorHelper = { getModel: () => model };
 
-  const $elem = $(cooked.string);
+  const $elem = $(`<div>${cooked.string}</div>`);
   checklistSyntax($elem[0], decoratorHelper);
 
   currentRaw = raw;

--- a/test/javascripts/lib/checklist-test.js
+++ b/test/javascripts/lib/checklist-test.js
@@ -35,22 +35,21 @@ acceptance("discourse-checklist | checklist", function (needs) {
     ]);
   });
 
-  test("works if clicked in a very small interval", async function (assert) {
+  test("make checkboxes readonly while updating", async function (assert) {
     const [$elem, updated] = await prepare(`
 [ ] first
 [x] second
-[ ] third
-[ ] fourth
-[x] fifth
-[x] sixth
     `);
 
-    $elem.find(".chcklst-box").each(() => $(this).click());
+    const $checklist = $elem.find(".chcklst-box");
+    $checklist.get(0).click();
+    const checkbox = $checklist.get(1);
+    assert.ok(checkbox.classList.contains("readonly"));
+    checkbox.click();
 
     const output = await updated;
     assert.ok(output.includes("[x] first"));
-    assert.ok(output.includes("[ ] second"));
-    assert.ok(output.includes("[x] third"));
+    assert.ok(output.includes("[x] second"));
   });
 
   test("checkbox before a code block", async function (assert) {


### PR DESCRIPTION
Else checking multiple checkboxes discards edits to all but the first box. This is happening when clicking checkboxes in a small time of interval.