### PR TITLE
UX: Use checkboxes as bullets in unordered lists

### DIFF
--- a/assets/javascripts/discourse/initializers/checklist.js
+++ b/assets/javascripts/discourse/initializers/checklist.js
@@ -15,12 +15,50 @@ function removeReadonlyClass(boxes) {
   boxes.forEach((e) => e.classList.remove("readonly"));
 }
 
+function isWhitespaceNode(node) {
+  return node.nodeType === 3 && node.nodeValue.match(/^\s*$/);
+}
+
+function hasPrecedingContent(node) {
+  let sibling = node.previousSibling;
+  while (sibling) {
+    if (!isWhitespaceNode(sibling)) {
+      return true;
+    }
+    sibling = sibling.previousSibling;
+  }
+  return false;
+}
+
+function addUlClasses(boxes) {
+  boxes.forEach((val) => {
+    let parent = val.parentElement;
+    if (
+      parent.nodeName === "P" &&
+      parent.parentElement.firstElementChild === parent
+    ) {
+      parent = parent.parentElement;
+    }
+    if (parent.nodeName === "LI" && parent.parentElement.nodeName === "UL") {
+      if (!hasPrecedingContent(val)) {
+        parent.classList.add("has-checkbox");
+        val.classList.add("list-item-checkbox");
+        if (!val.nextSibling) {
+          val.insertAdjacentHTML("afterend", "&#8203;"); // Ensure otherwise empty <li> does not collapse height
+        }
+      }
+    }
+  });
+}
+
 export function checklistSyntax(elem, postDecorator) {
+  const boxes = [...elem.getElementsByClassName("chcklst-box")];
+  addUlClasses(boxes);
+
   if (!postDecorator) {
     return;
   }
 
-  const boxes = [...elem.getElementsByClassName("chcklst-box")];
   const postWidget = postDecorator.widget;
   const postModel = postDecorator.getModel();
 

--- a/assets/stylesheets/checklist.scss
+++ b/assets/stylesheets/checklist.scss
@@ -63,6 +63,16 @@ span.chcklst-box {
   }
 }
 
+ul li.has-checkbox {
+  list-style-type: none;
+  position: relative;
+
+  .list-item-checkbox {
+    position: absolute;
+    left: -1.2em;
+  }
+}
+
 .fa-spin {
   display: inline-block;
   vertical-align: middle;

--- a/test/javascripts/lib/checklist-test.js
+++ b/test/javascripts/lib/checklist-test.js
@@ -189,4 +189,63 @@ Actual checkboxes:
     const output = await updated;
     assert.ok(output.includes("[ ] fourth"));
   });
+
+  test("rendering in bullet lists", async function (assert) {
+    const [$elem] = await prepare(`
+- [ ] LI 1
+- LI 2 [ ] with checkbox in middle
+- [ ] LI 3
+
+1. [ ] Ordered LI with checkbox
+    `);
+    const elem = $elem[0];
+
+    const listItems = [...elem.querySelector("ul").children];
+    assert.equal(listItems.length, 3);
+
+    assert.true(
+      listItems[0].classList.contains("has-checkbox"),
+      "LI 1 has `.has-checkbox` class"
+    );
+    assert.true(
+      listItems[0]
+        .querySelector(".chcklst-box")
+        .classList.contains("list-item-checkbox"),
+      "LI 1 checkbox has `.list-item-checkbox`"
+    );
+
+    assert.false(
+      listItems[1].classList.contains("has-checkbox"),
+      "LI 2 does not have `.has-checkbox` class"
+    );
+    assert.false(
+      listItems[1]
+        .querySelector(".chcklst-box")
+        .classList.contains("list-item-checkbox"),
+      "LI 2 checkbox does not have `.list-item-checkbox`"
+    );
+
+    assert.true(
+      listItems[2].classList.contains("has-checkbox"),
+      "LI 3 has `.has-checkbox` class"
+    );
+    assert.true(
+      listItems[2]
+        .querySelector(".chcklst-box")
+        .classList.contains("list-item-checkbox"),
+      "LI 3 checkbox has `.list-item-checkbox`"
+    );
+
+    const orderedListItems = [...elem.querySelector("ol").children];
+    assert.false(
+      orderedListItems[0].classList.contains("has-checkbox"),
+      "OL does not have `.has-checkbox` class"
+    );
+    assert.false(
+      orderedListItems[0]
+        .querySelector(".chcklst-box")
+        .classList.contains("list-item-checkbox"),
+      "OL checkbox does not have `.list-item-checkbox`"
+    );
+  });
 });


### PR DESCRIPTION
This commit updates the styling of unordered list items when they begin with a checkbox. The checkbox essentially 'becomes' the bullet, making for a less busy UI.

**Before:**
<img width="738" alt="Screenshot 2022-12-02 at 18 13 55" src="https://user-images.githubusercontent.com/6270921/205359219-5e9ed912-9aa6-4588-b640-e05ffe070dbf.png">

**After:**
<img width="725" alt="Screenshot 2022-12-02 at 18 13 39" src="https://user-images.githubusercontent.com/6270921/205359260-4e30588f-2f1f-4df2-b66d-ddb7b75d9b70.png">
