### PR TITLE
DEV: Fix admin dashboard messsage

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -7,8 +7,8 @@
 # url: https://github.com/discourse/discourse-checklist
 # transpile_js: true
 
-AdminDashboardData.add_problem_check do
-  I18n.t(
-    "The discourse-checklist plugin has been integrated into discourse core. Please remove the plugin from your app.yml and rebuild your container.",
-  )
+after_initialize do
+  AdminDashboardData.add_problem_check do
+    "The discourse-checklist plugin has been integrated into discourse core. Please remove the plugin from your app.yml and rebuild your container."
+  end
 end


### PR DESCRIPTION
AdminDashboardData isn't necessarily available when `plugin.rb` is being evaluated (sometimes it can be... but that depends on which other plugins you have installed). Wrapping in after_initialize solves this.

Also remove the unneeded `I18n.t`